### PR TITLE
DataSpace can be included and localized in relational stores

### DIFF
--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFourthPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementFourthPassBuilder.java
@@ -16,6 +16,7 @@ package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
 import org.eclipse.collections.api.RichIterable;
 import org.eclipse.collections.api.list.MutableList;
+import org.eclipse.collections.api.tuple.Pair;
 import org.eclipse.collections.impl.factory.Lists;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
@@ -36,6 +37,8 @@ import org.finos.legend.engine.shared.core.operational.logs.LogInfo;
 import org.finos.legend.engine.shared.core.operational.logs.LoggingEventType;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_relationship_Generalization_Impl;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.AssociationImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EmbeddedSetImplementation;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.PackageableElement;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.relationship.Generalization;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
@@ -154,6 +157,11 @@ public class PackageableElementFourthPassBuilder implements PackageableElementVi
     public PackageableElement visit(Mapping mapping)
     {
         final org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping pureMapping = this.context.pureModel.getMapping(this.context.pureModel.buildPackageString(mapping._package, mapping.name), mapping.sourceInformation);
+        if (mapping.classMappings != null && pureMapping._classMappings().isEmpty())
+        {
+            RichIterable<Pair<SetImplementation, RichIterable<EmbeddedSetImplementation>>> setImplementations = ListIterate.collect(mapping.classMappings, cm -> cm.accept(new ClassMappingFirstPassBuilder(this.context, pureMapping)));
+            pureMapping._classMappingsAddAll(setImplementations.flatCollect(p -> Lists.mutable.with(p.getOne()).withAll(p.getTwo())));
+        }
         if (mapping.associationMappings != null)
         {
             RichIterable<AssociationImplementation> associationImplementations = ListIterate.collect(mapping.associationMappings, cm -> HelperMappingBuilder.processAssociationImplementation(cm, this.context, pureMapping));

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/PackageableElementSecondPassBuilder.java
@@ -198,33 +198,9 @@ public class PackageableElementSecondPassBuilder implements PackageableElementVi
     {
         final org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping pureMapping = this.context.pureModel.getMapping(this.context.pureModel.buildPackageString(mapping._package, mapping.name), mapping.sourceInformation);
         RichIterable<org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EnumerationMapping<Object>> enumerationMappings = ListIterate.collect(mapping.enumerationMappings, em -> HelperMappingBuilder.processEnumMapping(em, pureMapping, this.context));
-        if (enumerationMappings.isEmpty() && mapping.includedMappings.isEmpty())
+        if (enumerationMappings.isEmpty())
         {
             return pureMapping;
-        }
-        if (!mapping.includedMappings.isEmpty())
-        {
-            CompilerExtensions extensions = context.pureModel.extensions;
-            RichIterable<org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.MappingInclude> mappingIncludes =
-                    ListIterate.collect(mapping.includedMappings, i ->
-                    {
-                        IncludedMappingHandler handler = extensions.getExtraIncludedMappingHandlers(i.getClass().getName());
-                        return handler.processMappingInclude(i, this.context, pureMapping,
-                                handler.resolveMapping(i, this.context));
-                    });
-            pureMapping._includesAddAll(mappingIncludes);
-            // validate no duplicated included mappings
-            Set<String> uniqueMappingIncludes = new HashSet<>();
-            mappingIncludes.forEach(includedMapping ->
-            {
-                String mappingName = IncludedMappingHandler.parseIncludedMappingNameRecursively(includedMapping);
-                if (!uniqueMappingIncludes.add(mappingName))
-                {
-                    throw new EngineException("Duplicated mapping include '" + mappingName +
-                            "' in " + "mapping " +
-                            "'" + this.context.pureModel.buildPackageString(mapping._package, mapping.name) + "'", mapping.sourceInformation, EngineErrorType.COMPILATION);
-                }
-            });
         }
         pureMapping._enumerationMappings(enumerationMappings);
         return pureMapping;

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtension.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtension.java
@@ -36,6 +36,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.aggregationAware.AggregationAwareClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.IncludedStore;
 import org.finos.legend.engine.protocol.pure.v1.model.test.Test;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.TestAssertion;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.ValueSpecification;
@@ -48,6 +49,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.EmbeddedSetImplem
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 
 import java.util.Collections;
 import java.util.List;
@@ -195,6 +197,11 @@ public interface CompilerExtension
     }
 
     default Map<String, IncludedMappingHandler> getExtraIncludedMappingHandlers()
+    {
+        return Maps.mutable.empty();
+    }
+
+    default Map<String, Function2<IncludedStore, CompileContext, RichIterable<Store>>> getExtraIncludedStoreHandlers()
     {
         return Maps.mutable.empty();
     }

--- a/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtensions.java
+++ b/legend-engine-language-pure-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/extension/CompilerExtensions.java
@@ -47,6 +47,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.ClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.aggregationAware.AggregationAwareClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.IncludedStore;
 import org.finos.legend.engine.protocol.pure.v1.model.test.Test;
 import org.finos.legend.engine.protocol.pure.v1.model.test.assertion.TestAssertion;
 import org.finos.legend.engine.protocol.pure.v1.model.valueSpecification.raw.executionContext.ExecutionContext;
@@ -60,6 +61,7 @@ import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SetImplementation;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.function.LambdaFunction;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.metamodel.valuespecification.ValueSpecification;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,6 +116,7 @@ public class CompilerExtensions
     private final ImmutableList<BiConsumer<PureModel, MappingValidatorContext>> extraMappingPostValidators;
 
     private final Map<String, IncludedMappingHandler> extraIncludedMappingHandlers;
+    private final Map<String, Function2<IncludedStore, CompileContext, RichIterable<Store>>> extraIncludedStoreHandlers;
 
     private CompilerExtensions(Iterable<? extends CompilerExtension> extensions)
     {
@@ -146,6 +149,8 @@ public class CompilerExtensions
         this.extraMappingPostValidators = this.extensions.flatCollect(CompilerExtension::getExtraMappingPostValidators);
         this.extraIncludedMappingHandlers = Maps.mutable.empty();
         this.extensions.forEach(e -> extraIncludedMappingHandlers.putAll(e.getExtraIncludedMappingHandlers()));
+        this.extraIncludedStoreHandlers = Maps.mutable.empty();
+        this.extensions.forEach(e -> this.extraIncludedStoreHandlers.putAll(e.getExtraIncludedStoreHandlers()));
     }
 
     public List<CompilerExtension> getExtensions()
@@ -467,5 +472,17 @@ public class CompilerExtensions
     public IncludedMappingHandler getExtraIncludedMappingHandlers(String classType)
     {
         return this.extraIncludedMappingHandlers.get(classType);
+    }
+
+    public Function2<IncludedStore, CompileContext, RichIterable<Store>> getExtraIncludedStoreHandlers(IncludedStore includedStore)
+    {
+        if (this.extraIncludedStoreHandlers.get(includedStore.type) == null)
+        {
+            throw new EngineException("Compilation handler for the included store type does not exist.", EngineErrorType.COMPILATION);
+        }
+        else
+        {
+            return this.extraIncludedStoreHandlers.get(includedStore.type);
+        }
     }
 }

--- a/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/mapping/MappingLexerGrammar.g4
+++ b/legend-engine-language-pure-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/mapping/MappingLexerGrammar.g4
@@ -16,7 +16,7 @@ IMPORT:                                 'import';
 INCLUDE:                                'include';
 TESTS:                                  'MappingTests';
 EXTENDS:                                'extends';
-INCLUDETYPE:                        'include '[a-z]([a-z])*' ';
+INCLUDETYPE:                            'include '[a-z]([a-z])*' ';
 
 //--------------------------------------- TEST ------------------------------------------
 TEST_QUERY:                             'query';

--- a/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtension.java
+++ b/legend-engine-language-pure-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/extension/PureGrammarParserExtension.java
@@ -14,11 +14,17 @@
 
 package org.finos.legend.engine.language.pure.grammar.from.extension;
 
+import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.grammar.from.extension.data.EmbeddedDataParser;
 import org.finos.legend.engine.language.pure.grammar.from.extension.test.assertion.TestAssertionParser;
 import org.finos.legend.engine.language.pure.grammar.from.mapping.MappingIncludeParser;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 
 import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
 
 public interface PureGrammarParserExtension
 {
@@ -58,6 +64,28 @@ public interface PureGrammarParserExtension
     }
 
     default Iterable<? extends MappingIncludeParser> getExtraMappingIncludeParsers()
+    {
+        return Collections.emptyList();
+    }
+
+    static String parseIncludedStoreType(String type, List<Function<String, String>> processors)
+    {
+        List<String> results = ListIterate.collect(processors, func -> func.apply(type)).select(Objects::nonNull);
+        if (results.isEmpty())
+        {
+            throw new EngineException("Unsupported included store type: " + type, EngineErrorType.PARSER);
+        }
+        else if (results.size() > 1)
+        {
+            throw new EngineException("Too many parsers for provided type: " + type, EngineErrorType.PARSER);
+        }
+        else
+        {
+            return results.get(0);
+        }
+    }
+
+    default List<Function<String, String>> getExtraIncludedStoreParsers()
     {
         return Collections.emptyList();
     }

--- a/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/IncludedStore.java
+++ b/legend-engine-protocol-pure/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/store/IncludedStore.java
@@ -14,12 +14,11 @@
 
 package org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store;
 
-import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.PackageableElement;
+import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 
-import java.util.Collections;
-import java.util.List;
-
-public abstract class Store extends PackageableElement
+public class IncludedStore
 {
-    public List<IncludedStore> includedStores = Collections.emptyList();
+    public String type;
+    public String name;
+    public SourceInformation sourceInformation;
 }

--- a/legend-engine-xt-data-space-compiler/pom.xml
+++ b/legend-engine-xt-data-space-compiler/pom.xml
@@ -45,6 +45,10 @@
             <artifactId>legend-pure-runtime-java-extension-dsl-mapping</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.finos.legend.pure</groupId>
+            <artifactId>legend-pure-m2-store-relational-pure</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-pure-code-compiled-core</artifactId>
         </dependency>
@@ -125,6 +129,16 @@
         <dependency>
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-dsl-service</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-protocol</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- TEST -->

--- a/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceIncludedMappingHandler.java
+++ b/legend-engine-xt-data-space-compiler/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/DataSpaceIncludedMappingHandler.java
@@ -14,11 +14,17 @@
 
 package org.finos.legend.engine.language.pure.compiler.toPureGraph;
 
+import org.eclipse.collections.api.RichIterable;
 import org.finos.legend.engine.language.pure.compiler.toPureGraph.handlers.IncludedMappingHandler;
+import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.dataSpace.MappingIncludeDataSpace;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.MappingInclude;
+import org.finos.legend.engine.shared.core.operational.errorManagement.EngineException;
 import org.finos.legend.pure.generated.Root_meta_pure_mapping_MappingInclude_Impl;
+import org.finos.legend.pure.generated.Root_meta_pure_mapping_SubstituteStore_Impl;
 import org.finos.legend.pure.generated.Root_meta_pure_metamodel_dataSpace_DataSpace;
 import org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.Mapping;
+import org.finos.legend.pure.m3.coreinstance.meta.pure.store.Store;
 
 public class DataSpaceIncludedMappingHandler implements IncludedMappingHandler
 {
@@ -27,6 +33,10 @@ public class DataSpaceIncludedMappingHandler implements IncludedMappingHandler
     {
         Root_meta_pure_metamodel_dataSpace_DataSpace dataspace =
                 DataSpaceCompilerExtension.dataSpacesIndex.get(mappingInclude.getFullName());
+        if (dataspace == null)
+        {
+            throw new EngineException("Included dataspace " + mappingInclude.getFullName() + " does not exist.", mappingInclude.sourceInformation, EngineErrorType.COMPILATION);
+        }
         return dataspace._defaultExecutionContext()._mapping();
     }
 
@@ -36,6 +46,28 @@ public class DataSpaceIncludedMappingHandler implements IncludedMappingHandler
         org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.MappingInclude include = new Root_meta_pure_mapping_MappingInclude_Impl("", null, context.pureModel.getClass("meta::pure::mapping::MappingInclude"));
         include._owner(parentMapping);
         include._included(includedMapping);
+
+        MappingIncludeDataSpace mappingIncludeDataSpace = (MappingIncludeDataSpace) mappingInclude;
+        if (mappingIncludeDataSpace.sourceDatabasePath != null && mappingIncludeDataSpace.targetDatabasePath != null)
+        {
+            if (!mappingIncludeDataSpace.sourceDatabasePath.equals(mappingIncludeDataSpace.getFullName()))
+            {
+                throw new EngineException("Referenced SourceDatabase " + mappingIncludeDataSpace.sourceDatabasePath + " must match the included DataSpace " + mappingIncludeDataSpace.getFullName(),
+                        mappingIncludeDataSpace.sourceInformation,
+                        EngineErrorType.COMPILATION);
+            }
+            Root_meta_pure_metamodel_dataSpace_DataSpace dataspace =
+                    DataSpaceCompilerExtension.dataSpacesIndex.get(mappingInclude.getFullName());
+            RichIterable<Store> databases = DataSpaceCompilerExtension.getDatabasesUnderDataSpace(dataspace, context);
+            for (Store database : databases)
+            {
+                org.finos.legend.pure.m3.coreinstance.meta.pure.mapping.SubstituteStore substituteStore = new Root_meta_pure_mapping_SubstituteStore_Impl("", null, context.pureModel.getClass("meta::pure::mapping::SubstituteStore"));
+                substituteStore._owner(include);
+                substituteStore._original(database);
+                substituteStore._substitute(context.resolveStore(mappingIncludeDataSpace.targetDatabasePath));
+                include._storeSubstitutionsAdd(substituteStore);
+            }
+        }
         return include;
     }
 }

--- a/legend-engine-xt-data-space-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
+++ b/legend-engine-xt-data-space-compiler/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestDataSpaceCompilationFromGrammar.java
@@ -76,6 +76,154 @@ public class TestDataSpaceCompilationFromGrammar extends TestCompilationFromGram
     }
 
     @Test
+    public void testIncludeDataSpaceInStore()
+    {
+        test("###Pure\n" +
+                "Class meta::Firm\n" +
+                "{\n" +
+                "  name: String[1];\n" +
+                "  id: Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "###Relational\n" +
+                "Database meta::producer::FirmDb\n" +
+                "(\n" +
+                "  Table FirmTable\n" +
+                "  (\n" +
+                "    Id INTEGER PRIMARY KEY,\n" +
+                "    FirmName VARCHAR(200)\n" +
+                "  )\n" +
+                ")\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping meta::producer::FirmMapping\n" +
+                "(\n" +
+                "  *meta::Firm: Relational\n" +
+                "  {\n" +
+                "    ~primaryKey\n" +
+                "    (\n" +
+                "      [meta::producer::FirmDb]FirmTable.Id\n" +
+                "    )\n" +
+                "    ~mainTable [meta::producer::FirmDb]FirmTable\n" +
+                "    name: [meta::producer::FirmDb]FirmTable.FirmName,\n" +
+                "    id: [meta::producer::FirmDb]FirmTable.Id\n" +
+                "  }\n" +
+                ")\n" +
+                "\n" +
+                "###Connection\n" +
+                "RelationalDatabaseConnection meta::producer::FirmConnection\n" +
+                "{\n" +
+                "  store: meta::producer::FirmDb;\n" +
+                "  type: H2;\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "    testDataSetupSqls: [\n" +
+                "      'Drop table if exists firmTable;\\nCreate Table firmTable(FirmCode INT, FirmName VARCHAR(200));\\nInsert into firmTable (FirmCode, FirmName) values (101,\\'finos\\');\\nInsert into firmTable (FirmCode, FirmName) values (200,\\'goldman_Sachs\\');'\n" +
+                "      ];\n" +
+                "  };\n" +
+                "  auth: DefaultH2;\n" +
+                "}\n" +
+                "###Runtime\n" +
+                "Runtime meta::producer::FirmRuntime\n" +
+                "{\n" +
+                "  mappings:\n" +
+                "  [\n" +
+                "    meta::producer::FirmMapping\n" +
+                "  ];\n" +
+                "  connections:\n" +
+                "  [\n" +
+                "    meta::producer::FirmDb:\n" +
+                "    [\n" +
+                "      connection_2: meta::producer::FirmConnection\n" +
+                "    ]\n" +
+                "  ];\n" +
+                "}\n" +
+                "\n" +
+                "###DataSpace\n" +
+                "DataSpace meta::producer::FirmDataSpace" +
+                "{\n" +
+                "  executionContexts:\n" +
+                "  [\n" +
+                "    {\n" +
+                "      name: 'Context 1';\n" +
+                "      description: 'some information about the context';\n" +
+                "      mapping: meta::producer::FirmMapping;\n" +
+                "      defaultRuntime: meta::producer::FirmRuntime;\n" +
+                "    }\n" +
+                "  ];\n" +
+                "  defaultExecutionContext: 'Context 1';\n" +
+                "}\n" +
+                "\n" +
+                "###Pure\n" +
+                "Class meta::Employee\n" +
+                "{\n" +
+                "  name: String[1];\n" +
+                "  id: Integer[1];\n" +
+                "  firmId: Integer[1];\n" +
+                "}\n" +
+                "\n" +
+                "###Relational\n" +
+                "Database meta::producer::EmployeeDb\n" +
+                "(\n" +
+                "  include dataspace meta::producer::FirmDataSpace" +
+                "  Table employeeTable\n" +
+                "  (\n" +
+                "    FirmId INTEGER,\n" +
+                "    Id INTEGER PRIMARY KEY,\n" +
+                "    EmployeeName VARCHAR(200)\n" +
+                "  )\n" +
+                ")\n" +
+                "\n" +
+                "###Mapping\n" +
+                "Mapping meta::producer::EmployeeMapping\n" +
+                "(\n" +
+                "  include dataspace meta::producer::FirmDataSpace[meta::producer::FirmDataSpace -> meta::producer::EmployeeDb]" +
+                "  *meta::Employee: Relational\n" +
+                "  {\n" +
+                "    ~primaryKey\n" +
+                "    (\n" +
+                "      [meta::producer::EmployeeDb]employeeTable.Id\n" +
+                "    )\n" +
+                "    ~mainTable [meta::producer::EmployeeDb]employeeTable\n" +
+                "    name: [meta::producer::EmployeeDb]employeeTable.EmployeeName,\n" +
+                "    id: [meta::producer::EmployeeDb]employeeTable.Id,\n" +
+                "    firmId: [meta::producer::EmployeeDb]employeeTable.FirmId\n" +
+                "  }\n" +
+                ")\n" +
+                "\n" +
+                "###Connection\n" +
+                "RelationalDatabaseConnection meta::producer::EmployeeConnection\n" +
+                "{\n" +
+                "  store: meta::producer::EmployeeDb;\n" +
+                "  type: H2;\n" +
+                "  specification: LocalH2\n" +
+                "  {\n" +
+                "    testDataSetupSqls: [\n" +
+                "      'Drop table if exists firmTable;\\nCreate Table firmTable(FirmCode INT, FirmName VARCHAR(200));\\nInsert into firmTable (FirmCode, FirmName) values (101,\\'finos\\');\\nInsert into firmTable (FirmCode, FirmName) values (200,\\'goldman_Sachs\\');'\n" +
+                "      ];\n" +
+                "  };\n" +
+                "  auth: DefaultH2;\n" +
+                "}\n" +
+                "\n" +
+                "###Runtime\n" +
+                "Runtime meta::producer::EmployeeRuntime\n" +
+                "{\n" +
+                "  mappings:\n" +
+                "  [\n" +
+                "    meta::producer::EmployeeMapping\n" +
+                "  ];\n" +
+                "  connections:\n" +
+                "  [\n" +
+                "    meta::producer::EmployeeDb:\n" +
+                "    [\n" +
+                "      connection_2: meta::producer::EmployeeConnection\n" +
+                "    ]\n" +
+                "  ];\n" +
+                "}\n"
+        );
+    }
+
+    @Test
     public void testDuplicateMappingIncludeDataspaceWithImport()
     {
         String models = "Class test::A extends test::B {\n" +
@@ -113,7 +261,7 @@ public class TestDataSpaceCompilationFromGrammar extends TestCompilationFromGram
                 "{\n" +
                 "  mappings:\n" +
                 "  [\n" +
-                "    model::dummyMapping\n" +
+                "    model::mapping::dummyMapping\n" +
                 "  ];\n" +
                 "}\n" +
                 "\n" +
@@ -131,8 +279,9 @@ public class TestDataSpaceCompilationFromGrammar extends TestCompilationFromGram
                 "    }\n" +
                 "  ];\n" +
                 "  defaultExecutionContext: 'Context 1';\n" +
-                "}\n", "COMPILATION error at [20:1-26:1]: Duplicated mapping include " +
-                "'model::mapping::dummyMapping' in mapping 'test::M1'");
+                "}\n",
+                "COMPILATION error at [20:1-26:1]: Duplicated mapping include " + "'model::mapping::dummyMapping' in mapping 'test::M1'"
+        );
     }
 
     @Override

--- a/legend-engine-xt-data-space-grammar/pom.xml
+++ b/legend-engine-xt-data-space-grammar/pom.xml
@@ -87,6 +87,10 @@
             <groupId>org.finos.legend.engine</groupId>
             <artifactId>legend-engine-language-pure-grammar</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.finos.legend.engine</groupId>
+            <artifactId>legend-engine-xt-relationalStore-grammar</artifactId>
+        </dependency>
         <!-- ENGINE -->
 
         <!-- ECLIPSE COLLECTIONS -->

--- a/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/DataSpaceParserExtension.java
+++ b/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/DataSpaceParserExtension.java
@@ -31,9 +31,11 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.Section;
 
 import java.util.Collections;
+import java.util.List;
 import java.util.function.Consumer;
+import java.util.function.Function;
 
-public class DataSpaceParserExtension implements PureGrammarParserExtension
+public class DataSpaceParserExtension implements IRelationalGrammarParserExtension
 {
     public static final String NAME = "DataSpace";
 
@@ -82,7 +84,38 @@ public class DataSpaceParserExtension implements PureGrammarParserExtension
         mappingIncludeDataSpace.includedDataSpace =
                 PureGrammarParserUtility.fromQualifiedName(ctx.qualifiedName().packagePath() == null ? Collections.emptyList() : ctx.qualifiedName().packagePath().identifier(), ctx.qualifiedName().identifier());
         mappingIncludeDataSpace.sourceInformation = walkerSourceInformation.getSourceInformation(ctx);
+        List<MappingParserGrammar.StoreSubPathContext> storeSubPathContextList = ctx.storeSubPath();
+        if (storeSubPathContextList.size() == 1)
+        {
+            MappingParserGrammar.StoreSubPathContext storeSubPathContext = storeSubPathContextList.get(0);
+            mappingIncludeDataSpace.sourceDatabasePath =
+                    PureGrammarParserUtility.fromQualifiedName(storeSubPathContext.sourceStore().qualifiedName().packagePath() == null ? Collections.emptyList() : storeSubPathContext.sourceStore().qualifiedName().packagePath().identifier(), storeSubPathContext.sourceStore().qualifiedName().identifier());
+            mappingIncludeDataSpace.targetDatabasePath =
+                    PureGrammarParserUtility.fromQualifiedName(storeSubPathContext.targetStore().qualifiedName().packagePath() == null ? Collections.emptyList() : storeSubPathContext.targetStore().qualifiedName().packagePath().identifier(), storeSubPathContext.targetStore().qualifiedName().identifier());
+        }
+        else
+        {
+            mappingIncludeDataSpace.targetDatabasePath = null;
+        }
 
         return mappingIncludeDataSpace;
+    }
+
+    @Override
+    public List<Function<String, String>> getExtraIncludedStoreParsers()
+    {
+        return Lists.mutable.of(this::parseIncludedStore);
+    }
+
+    private String parseIncludedStore(String type)
+    {
+        if (type.equals("dataspace"))
+        {
+            return "dataspace";
+        }
+        else
+        {
+            return null;
+        }
     }
 }

--- a/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
+++ b/legend-engine-xt-data-space-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/DataSpaceGrammarComposerExtension.java
@@ -160,7 +160,11 @@ public class DataSpaceGrammarComposerExtension implements PureGrammarComposerExt
         if (mappingInclude.getClass() == MappingIncludeDataSpace.class)
         {
             MappingIncludeDataSpace mappingIncludeDataSpace = (MappingIncludeDataSpace) mappingInclude;
-            return "include dataspace " + mappingIncludeDataSpace.includedDataSpace;
+            return "include dataspace " + mappingIncludeDataSpace.includedDataSpace
+                    + (mappingIncludeDataSpace.targetDatabasePath != null
+                    ? "[" + mappingIncludeDataSpace.sourceDatabasePath + " -> " + mappingIncludeDataSpace.targetDatabasePath + "]"
+                    : ""
+            );
         }
         return null;
     }

--- a/legend-engine-xt-data-space-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.from.IRelationalGrammarParserExtension
+++ b/legend-engine-xt-data-space-grammar/src/main/resources/META-INF/services/org.finos.legend.engine.language.pure.grammar.from.IRelationalGrammarParserExtension
@@ -1,0 +1,1 @@
+org.finos.legend.engine.language.pure.grammar.from.DataSpaceParserExtension

--- a/legend-engine-xt-data-space-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestDataSpaceIncludeGrammarRoundtrip.java
+++ b/legend-engine-xt-data-space-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestDataSpaceIncludeGrammarRoundtrip.java
@@ -27,6 +27,7 @@ public class TestDataSpaceIncludeGrammarRoundtrip extends TestGrammarRoundtrip.T
                 "  include mapping meta::pure::mapping::includedMapping\n" +
                 "  include mapping meta::pure::mapping::DispatchMapping\n" +
                 "  include dataspace meta::pure::dataspace::IncludedDataSpace\n" +
+                "  include dataspace meta::pure::dataspace::IncludedDataSpace2[meta::pure::dataspace::IncludedDataSpace2 -> meta::test::simpleModelStore]\n" +
                 "\n" +
                 "  *meta::pure::mapping::modelToModel::test::shared::dest::Person[meta_pure_mapping_modelToModel_test_shared_dest_Person]: Pure\n" +
                 "  {\n" +

--- a/legend-engine-xt-data-space-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/dataSpace/MappingIncludeDataSpace.java
+++ b/legend-engine-xt-data-space-protocol/src/main/java/org/finos/legend/engine/protocol/pure/v1/model/packageableElement/dataSpace/MappingIncludeDataSpace.java
@@ -20,6 +20,8 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 public class MappingIncludeDataSpace extends MappingInclude
 {
     public String includedDataSpace;
+    public String sourceDatabasePath;
+    public String targetDatabasePath;
 
     @JsonIgnore
     public String getFullName()

--- a/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalLexerGrammar.g4
+++ b/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalLexerGrammar.g4
@@ -8,6 +8,7 @@ import CoreLexerGrammar;
 DATABASE:                                   'Database';
 
 INCLUDE:                                    'include';
+INCLUDETYPE:                                'include '[a-z]([a-z])*' ';
 
 TABLE:                                      'Table';
 SCHEMA:                                     'Schema';

--- a/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
+++ b/legend-engine-xt-relationalStore-grammar/src/main/antlr4/org/finos/legend/engine/language/pure/grammar/from/antlr4/RelationalParserGrammar.g4
@@ -41,7 +41,7 @@ database:                                   DATABASE qualifiedName
                                                     )*
                                                 PAREN_CLOSE
 ;
-include:                                    INCLUDE qualifiedName
+include:                                    (INCLUDETYPE|INCLUDE) qualifiedName
 ;
 
 

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/compiler/toPureGraph/RelationalCompilerExtension.java
@@ -29,6 +29,7 @@ import org.eclipse.collections.api.map.MutableMap;
 import org.eclipse.collections.api.multimap.Multimap;
 import org.eclipse.collections.api.set.MutableSet;
 import org.eclipse.collections.api.tuple.Pair;
+import org.eclipse.collections.impl.factory.Iterables;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.tuple.Tuples;
 import org.eclipse.collections.impl.utility.ListIterate;
@@ -48,6 +49,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.aggregationAware.AggregateSetImplementationContainer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.aggregationAware.AggregationAwareClassMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.mappingTest.InputData;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.IncludedStore;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.RelationalDatabaseConnection;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.authentication.AuthenticationStrategy;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.connection.postprocessor.MapperPostProcessor;
@@ -87,6 +89,7 @@ import org.finos.legend.pure.runtime.java.compiled.generation.processors.support
 
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import java.util.function.BiConsumer;
 
@@ -116,15 +119,15 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
                 (Database srcDatabase, CompileContext context) ->
                 {
                     org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database database = HelperRelationalBuilder.getDatabase(context.pureModel.buildPackageString(srcDatabase._package, srcDatabase.name), srcDatabase.sourceInformation, context);
-                    if (!srcDatabase.includedStores.isEmpty())
-                    {
-                        database._includes(ListIterate.collect(srcDatabase.includedStores, include -> HelperRelationalBuilder.resolveDatabase(context.pureModel.addPrefixToTypeReference(include), srcDatabase.sourceInformation, context)));
-                    }
-                    database._schemas(ListIterate.collect(srcDatabase.schemas, _schema -> HelperRelationalBuilder.processDatabaseSchema(_schema, context, database)));
                 },
                 (Database srcDatabase, CompileContext context) ->
                 {
                     org.finos.legend.pure.m3.coreinstance.meta.relational.metamodel.Database database = HelperRelationalBuilder.getDatabase(context.pureModel.buildPackageString(srcDatabase._package, srcDatabase.name), srcDatabase.sourceInformation, context);
+                    if (!srcDatabase.includedStores.isEmpty())
+                    {
+                        database._includes(ListIterate.flatCollect(srcDatabase.includedStores, include -> context.pureModel.extensions.getExtraIncludedStoreHandlers(include).apply(include, context)));
+                    }
+                    database._schemas(ListIterate.collect(srcDatabase.schemas, _schema -> HelperRelationalBuilder.processDatabaseSchema(_schema, context, database)));
                     ListIterate.forEach(srcDatabase.schemas, _schema -> HelperRelationalBuilder.processDatabaseSchemaViewsFirstPass(_schema, context, database));
                 },
                 (Database srcDatabase, CompileContext context) ->
@@ -592,4 +595,11 @@ public class RelationalCompilerExtension implements IRelationalCompilerExtension
         return Collections.singletonList(RelationalValidator::validateRelationalMapping);
     }
 
+    @Override
+    public Map<String, Function2<IncludedStore, CompileContext, RichIterable<Store>>> getExtraIncludedStoreHandlers()
+    {
+        return org.eclipse.collections.impl.factory.Maps.mutable.of(
+                "database", (IncludedStore includedStore, CompileContext c) -> Iterables.iList(HelperRelationalBuilder.resolveDatabase(includedStore.name,includedStore.sourceInformation,c))
+        );
+    }
 }

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/IRelationalGrammarParserExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/IRelationalGrammarParserExtension.java
@@ -42,9 +42,11 @@ import java.util.function.Function;
 
 public interface IRelationalGrammarParserExtension extends PureGrammarParserExtension
 {
+    List<IRelationalGrammarParserExtension> extensions = Lists.mutable.withAll(ServiceLoader.load(IRelationalGrammarParserExtension.class));
+
     static List<IRelationalGrammarParserExtension> getExtensions()
     {
-        return Lists.mutable.withAll(ServiceLoader.load(IRelationalGrammarParserExtension.class));
+        return extensions;
     }
 
     static DatasourceSpecification process(DataSourceSpecificationSourceCode code, List<Function<DataSourceSpecificationSourceCode, DatasourceSpecification>> processors)

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalGrammarParserExtension.java
@@ -386,4 +386,23 @@ public class RelationalGrammarParserExtension implements IRelationalGrammarParse
             }
         }
     }
+
+    @Override
+    public List<Function<String, String>> getExtraIncludedStoreParsers()
+    {
+        return Lists.mutable.of(this::parseIncludedStore);
+    }
+
+    private String parseIncludedStore(String type)
+    {
+        if (type == null || type.equals("database"))
+        {
+            return "database";
+        }
+        else
+        {
+            return null;
+        }
+    }
+
 }

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/from/RelationalParseTreeWalker.java
@@ -23,6 +23,7 @@ import org.eclipse.collections.api.set.ImmutableSet;
 import org.eclipse.collections.impl.list.mutable.FastList;
 import org.eclipse.collections.impl.utility.ListIterate;
 import org.finos.legend.engine.language.pure.grammar.from.antlr4.RelationalParserGrammar;
+import org.finos.legend.engine.language.pure.grammar.from.extension.PureGrammarParserExtension;
 import org.finos.legend.engine.language.pure.grammar.from.milestoning.MilestoningSpecificationSourceCode;
 import org.finos.legend.engine.protocol.pure.v1.model.SourceInformation;
 import org.finos.legend.engine.protocol.pure.v1.model.context.EngineErrorType;
@@ -33,6 +34,7 @@ import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.PropertyMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.mapping.PropertyPointer;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.section.DefaultCodeSection;
+import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.IncludedStore;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.EmbeddedRelationalPropertyMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.FilterMapping;
 import org.finos.legend.engine.protocol.pure.v1.model.packageableElement.store.relational.mapping.FilterPointer;
@@ -116,7 +118,7 @@ public class RelationalParseTreeWalker
         database._package = ctx.qualifiedName().packagePath() == null ? "" : PureGrammarParserUtility.fromPath(ctx.qualifiedName().packagePath().identifier());
         database.sourceInformation = this.walkerSourceInformation.getSourceInformation(ctx);
         ScopeInfo scopeInfo = ScopeInfo.Builder.newInstance().withDatabase(PureGrammarParserUtility.fromQualifiedName(ctx.qualifiedName().packagePath() == null ? Collections.emptyList() : ctx.qualifiedName().packagePath().identifier(), ctx.qualifiedName().identifier())).build();
-        database.includedStores = ListIterate.collect(ctx.include(), includeContext -> PureGrammarParserUtility.fromQualifiedName(includeContext.qualifiedName().packagePath() == null ? Collections.emptyList() : includeContext.qualifiedName().packagePath().identifier(), includeContext.qualifiedName().identifier()));
+        database.includedStores = ListIterate.collect(ctx.include(), this::visitIncludedStores);
         database.schemas = ListIterate.collect(ctx.schema(), schemaCtx -> this.visitSchema(schemaCtx, scopeInfo));
         // NOTE: if tables and views are defined without a schema, create a default schema to hold these
         List<Table> tables = ListIterate.collect(ctx.table(), this::visitTable);
@@ -140,6 +142,15 @@ public class RelationalParseTreeWalker
         return database;
     }
 
+    private IncludedStore visitIncludedStores(RelationalParserGrammar.IncludeContext includeContext)
+    {
+        IncludedStore includedStore = new IncludedStore();
+        String type = includeContext.INCLUDETYPE() != null ? includeContext.INCLUDETYPE().getText().split(" ")[1] : "database";
+        includedStore.type = PureGrammarParserExtension.parseIncludedStoreType(type, ListIterate.flatCollect(IRelationalGrammarParserExtension.getExtensions(), PureGrammarParserExtension::getExtraIncludedStoreParsers));
+        includedStore.name = PureGrammarParserUtility.fromQualifiedName(includeContext.qualifiedName().packagePath() == null ? Collections.emptyList() : includeContext.qualifiedName().packagePath().identifier(), includeContext.qualifiedName().identifier());
+        includedStore.sourceInformation = this.walkerSourceInformation.getSourceInformation(includeContext);
+        return includedStore;
+    }
 
     // ----------------------------------------------- SCHEMA -----------------------------------------------
 

--- a/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/RelationalGrammarComposerExtension.java
+++ b/legend-engine-xt-relationalStore-grammar/src/main/java/org/finos/legend/engine/language/pure/grammar/to/RelationalGrammarComposerExtension.java
@@ -230,7 +230,7 @@ public class RelationalGrammarComposerExtension implements IRelationalGrammarCom
         boolean nonEmpty = false;
         if (!database.includedStores.isEmpty())
         {
-            builder.append(LazyIterate.collect(database.includedStores, include -> getTabString(1) + "include " + PureGrammarComposerUtility.convertPath(include)).makeString("\n"));
+            builder.append(LazyIterate.collect(database.includedStores, include -> getTabString(1) + "include " + include.type + " " + PureGrammarComposerUtility.convertPath(include.name)).makeString("\n"));
             builder.append("\n");
             nonEmpty = true;
         }

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/compiler/test/TestRelationalCompilationFromGrammar.java
@@ -430,7 +430,7 @@ public class TestRelationalCompilationFromGrammar extends TestCompilationFromGra
                         "    include model::relational::tests::dbInc\n" +
                         "    Table personTable (ID INT PRIMARY KEY, MANAGERID INT)\n" +
                         ")",
-                "COMPILATION error at [2:1-6:1]: Can't find database 'model::relational::tests::dbInc'"
+                "COMPILATION error at [4:5-43]: Can't find database 'model::relational::tests::dbInc'"
         );
 
         test("###Relational\n" +

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalGrammarRoundtrip.java
@@ -159,11 +159,11 @@ public class TestRelationalGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
     @Test
     public void testRelationalDatabase()
     {
-        test("###Relational\n" +
+        testFormat("###Relational\n" +
                 "Database test::db\n" +
                 "(\n" +
-                "  include Store1\n" +
-                "  include test::Store2\n" +
+                "  include database Store1\n" +
+                "  include database test::Store2\n" +
                 "\n" +
                 "  Schema mySchema\n" +
                 "  (\n" +
@@ -194,7 +194,43 @@ public class TestRelationalGrammarRoundtrip extends TestGrammarRoundtrip.TestGra
                 "\n" +
                 "  Filter filter1(TAB2.col1 is not null)\n" +
                 "  MultiGrainFilter filter2(TAB1.col2 is null)\n" +
-                ")\n");
+                ")\n",
+                "###Relational\n" +
+                        "Database test::db\n" +
+                        "(\n" +
+                        "  include Store1\n" +
+                        "  include test::Store2\n" +
+                        "\n" +
+                        "  Schema mySchema\n" +
+                        "  (\n" +
+                        "  )\n" +
+                        "\n" +
+                        "  Table table1\n" +
+                        "  (\n" +
+                        "    col1 CHAR(32)\n" +
+                        "  )\n" +
+                        "  Table table2\n" +
+                        "  (\n" +
+                        "    col1 CHAR(32)\n" +
+                        "  )\n" +
+                        "\n" +
+                        "  View view1\n" +
+                        "  (\n" +
+                        "    ~filter filter1\n" +
+                        "    col1: test.col1\n" +
+                        "  )\n" +
+                        "  View view2\n" +
+                        "  (\n" +
+                        "    ~filter filter2\n" +
+                        "    col2: test.col2\n" +
+                        "  )\n" +
+                        "\n" +
+                        "  Join join1(TAB.col1 = {target}.col2)\n" +
+                        "  Join join2(TAB2.col3 = TAB3.col2)\n" +
+                        "\n" +
+                        "  Filter filter1(TAB2.col1 is not null)\n" +
+                        "  MultiGrainFilter filter2(TAB1.col2 is null)\n" +
+                        ")\n");
     }
 
     @Test

--- a/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
+++ b/legend-engine-xt-relationalStore-grammar/src/test/java/org/finos/legend/engine/language/pure/grammar/test/TestRelationalMappingGrammarRoundtrip.java
@@ -209,7 +209,53 @@ public class TestRelationalMappingGrammarRoundtrip extends TestGrammarRoundtrip.
     public void testNestedJoinFromIncludedDatabase()
 
     {
-        test("###Relational\n" +
+        testFormat("###Relational\n" +
+                "Database example::database\n" +
+                "(\n" +
+                "  include database example::databaseInc\n" +
+                "\n" +
+                "  Schema exampleRoot\n" +
+                "  (\n" +
+                "    Table TableC\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "\n" +
+                "    View dbView\n" +
+                "    (\n" +
+                "      nameL: exampleSub.TableASub.name,\n" +
+                "      rootTable: [example::databaseInc]@AtoB > [example::database]@BtoC | exampleRoot.TableC.name\n" +
+                "    )\n" +
+                "    View dbViewIncTable\n" +
+                "    (\n" +
+                "      nameL: exampleRoot.TableC.name,\n" +
+                "      incTable: [example::database]@BtoC > [example::database]@AtoB | [example::databaseInc]exampleSub.TableASub.name\n" +
+                "    )\n" +
+                "  )\n" +
+                "\n" +
+                "  Join BtoC([example::databaseInc]exampleSub.TableBSub.id = exampleRoot.TableC.id)\n" +
+                ")\n" +
+                "\n" +
+                "Database example::databaseInc\n" +
+                "(\n" +
+                "  Schema exampleSub\n" +
+                "  (\n" +
+                "    Table TableASub\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "    Table TableBSub\n" +
+                "    (\n" +
+                "      name VARCHAR(255),\n" +
+                "      id INTEGER PRIMARY KEY\n" +
+                "    )\n" +
+                "  )\n" +
+                "\n" +
+                "  Join AtoB(exampleSub.TableASub.id = exampleSub.TableBSub.id)\n" +
+                ")\n",
+                "###Relational\n" +
                 "Database example::database\n" +
                 "(\n" +
                 "  include example::databaseInc\n" +


### PR DESCRIPTION
#### What type of PR is this?

Improvement

#### What does this PR do / why is it needed ?

Consumers can include and localize the relational stores underneath a dataspace by using the existing include syntax for stores and mappings.
